### PR TITLE
Update functions.inc.php line 2873

### DIFF
--- a/core/functions.inc.php
+++ b/core/functions.inc.php
@@ -2870,7 +2870,7 @@ function core_do_get_config($engine) {
       $ext->add($context, $exten, '', new ext_set('__MONTH','${STRFTIME(${NOW},,%m)}'));
       $ext->add($context, $exten, '', new ext_set('__YEAR','${STRFTIME(${NOW},,%Y)}'));
       $ext->add($context, $exten, '', new ext_set('__TIMESTR','${YEAR}${MONTH}${DAY}-${STRFTIME(${NOW},,%H%M%S)}'));
-      $ext->add($context, $exten, '', new ext_set('__FROMEXTEN','${IF($[${LEN(${AMPUSER})}]?${AMPUSER}:${IF($[${LEN(${REALCALLERIDNUM})}]?${REALCALLERIDNUM}:unknown)})}'));
+      $ext->add($context, $exten, '', new ext_set('__FROMEXTEN','${IF($[${LEN(${AMPUSER})}]?${AMPUSER}:${IF($[${LEN(${REALCALLERIDNUM})}]?${REALCALLERIDNUM}:${CALLERID(num)})})}'));
       $ext->add($context, $exten, '', new ext_set('__CALLFILENAME','${ARG1}-${ARG2}-${FROMEXTEN}-${TIMESTR}-${UNIQUEID}'));
       $ext->add($context, $exten, '', new ext_goto('1','${ARG1}'));
 


### PR DESCRIPTION
//change line #2873
$ext->add($context, $exten, '', new ext_set('__FROMEXTEN','${IF($[${LEN(${AMPUSER})}]?${AMPUSER}:${IF($[${LEN(${REALCALLERIDNUM})}]?${REALCALLERIDNUM}:unknown)})}')); //after
ext_set('__FROMEXTEN','${IF($[${LEN(${AMPUSER})}]?${AMPUSER}:${IF($[${LEN(${REALCALLERIDNUM})}]?${REALCALLERIDNUM}:${CALLERID(num)} )})}')); está es una solución a cuando se deja la troncal para que grabe inmediatamente.
 /var/spool/asterisk/monitor/2022/09/07/force-8906060-unknow-20220907-113248-1662568368.4506.wav]
ahora
 /var/spool/asterisk/monitor/2022/09/07/force-8906060-6093701539-20220907-113248-1662568368.4506.wav]
de esta forma ahora el número de quien llama sale en el archivo sin el unknow.