### PR TITLE
Prevent empty addtocdr var

### DIFF
--- a/pinsets/functions.inc.php
+++ b/pinsets/functions.inc.php
@@ -146,6 +146,7 @@ function pinsets_edit($id,$post){
 	extract($post);
 	$passwords = pinsets_clean($passwords);
 	if(empty($description)) $description = _('Unnamed');
+	if(empty($addtocdr)) $addtocdr = 0;
 	$results = sql("UPDATE pinsets SET description = \"$description\", passwords = \"$passwords\", addtocdr = \"$addtocdr\", deptname = \"$deptname\" WHERE pinsets_id = \"$id\"");
 }
 

--- a/pinsets/functions.inc.php
+++ b/pinsets/functions.inc.php
@@ -136,6 +136,7 @@ function pinsets_add($post){
 	extract($post);
 	$passwords = pinsets_clean($passwords);
 	if(empty($description)) $description = _('Unnamed');
+	if(empty($addtocdr)) $addtocdr = 0;
 	$results = sql("INSERT INTO pinsets (description,passwords,addtocdr,deptname) values (\"$description\",\"$passwords\",\"$addtocdr\",\"$deptname\")");
 }
 


### PR DESCRIPTION
addtocdr variable empty causes mariadb insert error.