### PR TITLE
Support Asterisk certied version

### DIFF
--- a/framework/amp_conf/htdocs/admin/functions.inc.php
+++ b/framework/amp_conf/htdocs/admin/functions.inc.php
@@ -277,6 +277,9 @@ function engine_getinfo($force_read=false) {
         } elseif (preg_match('/Asterisk SVN-(\d+(\.\d+)*)(-?(\S*))/', $verinfo, $matches)) {
             $engine_info = array('engine'=>'asterisk', 'version' => $matches[1], 'additional' => $matches[4], 'raw' => $verinfo);
             $gotinfo = true;
+         } elseif (preg_match('/Asterisk certified\/(\d+(\.\d+)*)(-?(.*))$/', $verinfo, $matches)) {
+            $engine_info = array('engine'=>'asterisk', 'version' => $matches[1], 'additional' => $matches[4], 'raw' => $verinfo);
+            $gotinfo = true;
         } elseif (preg_match('/Asterisk SVN-branch-(\d+(\.\d+)*)-r(-?(\S*))/', $verinfo, $matches)) {
             $engine_info = array('engine'=>'asterisk', 'version' => $matches[1].'.'.$matches[4], 'additional' => $matches[4], 'raw' => $verinfo);
             $gotinfo = true;

--- a/framework/install_amp
+++ b/framework/install_amp
@@ -1268,7 +1268,8 @@ $verinfo = $tmpout;
 //  'asterisk'
 outn("Checking for Asterisk version..");
 if ((preg_match('/^Asterisk (\d+(\.\d+)*)(-?(.*))$/', $verinfo, $matches)) ||
-    (preg_match('/^Asterisk SVN-(\d+(\.\d+)*)(-?(.*))$/', $verinfo, $matches))) {
+    (preg_match('/^Asterisk SVN-(\d+(\.\d+)*)(-?(.*))$/', $verinfo, $matches)) ||
+    (preg_match('/^Asterisk certified\/(\d+(\.\d+)*)(-?(.*))$/', $verinfo, $matches))) {
     if ((version_compare($matches[1], "1.6") < 0)) {
         fatal("Asterisk 1.6, 1.8 or 10 is required for this version of IssabelPBX. Detected version is: ".$matches[1]);
     }


### PR DESCRIPTION
Add a new regular expression to support installations of the certified version of Asterisk.
Sample: Asterisk certified/16.8-cert14