### PR TITLE
Update functions.inc.php

### DIFF
--- a/core/functions.inc.php
+++ b/core/functions.inc.php
@@ -2222,7 +2222,7 @@ function core_do_get_config($engine) {
                 $ext->add('targeted-chanspy', '_.', '', new ext_set('spy_target','${CHANNELS(${CHAN}-)}'));
                 $ext->add('targeted-chanspy', '_.', '', new ext_execif('$["${spy_target}"!=""]','ExitWhile'));
                 $ext->add('targeted-chanspy', '_.', '', new ext_endwhile(''));
-                $ext->add('targeted-chanspy', '_.', '', new ext_execif('$["${spy_target}"!=""]','ChanSpy(${spy_target},dnqE))'));
+                $ext->add('targeted-chanspy', '_X.', '', new ext_execif('$["${spy_target}"!=""]','ChanSpy', '${spy_target},dnqE'));
                 $ext->add('targeted-chanspy', '_.', '', new ext_hangup(''));
                 //$ext->add('targeted-chanspy', '_.', '', new ext_goto('once-upon-a-time');
                 $ext->add('targeted-chanspy', 'h', '', new ext_hangup(''));


### PR DESCRIPTION
Corrects the warning received at runtime.
[2025-08-28 11:03:07] WARNING[246116][C-000e3612]: app.c:3114 parse_options: Unrecognized option: ')' [2025-08-28 11:03:07] WARNING[246116][C-000e3612]: app.c:3106 parse_options: Missing closing parenthesis for argument ')' in string ''